### PR TITLE
Fix an issue where the word of index 0 is ignored

### DIFF
--- a/Text2Emotion/__init__.py
+++ b/Text2Emotion/__init__.py
@@ -663,8 +663,7 @@ def get_emotion(input):
         for i in text:
             try:
                 a = df['Word'].index(i)
-                if a:
-                    emotions[df['Emotion'][a]] += 1
+                emotions[df['Emotion'][a]] += 1
             except:
                 pass
         if sum(emotions.values()) is 0:


### PR DESCRIPTION
- `0` is a falsy value.
- `ValueError` is raised if `i not in df['Word']`, so the `if` statement can be safely removed.